### PR TITLE
re-add tailscale acl lock comment

### DIFF
--- a/deploy/tofu/tailscale.tf
+++ b/deploy/tofu/tailscale.tf
@@ -1,5 +1,6 @@
 resource "tailscale_acl" "acl" {
   acl = <<EOF
+    // This tailnet's ACLs are maintained in https://github.com/HomeScaleCloud/homescale
     {
       "groups": {
         "group:lon1-core-admin": [


### PR DESCRIPTION
re-enable tailscale acl lock to git
from https://tailscale.com/kb/1306/gitops-acls-github - "To prevent other admins in your organization from accidentally changing your tailnet policy file, add the following comment as the first line in the policy file with the URL of your repository so the [Access Controls](https://login.tailscale.com/admin/acls) page can display a warning"